### PR TITLE
fix(build): windows compatibility for npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-app-boilerplate",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "dependencies": {
     "micro": "^9.3.3",
@@ -14,12 +14,12 @@
   "scripts": {
     "start": "run-p start:*",
     "start:app": "react-scripts start",
-    "start:server": "PORT=5000 cd api && yarn start:local",
+    "start:server": "cross-env PORT=5000 yarn --cwd ./api start:local",
     "build": "react-scripts build",
-    "test": "CI=true react-scripts test",
+    "test": "cross-env CI=true react-scripts test",
     "test:coverage": "npm test -- --coverage",
     "eject": "react-scripts eject",
-    "clean": "rm -rf .cache/ && rm -rf build && rm -rf coverage",
+    "clean": "rimraf .cache/ build coverage",
     "release": "standard-version",
     "cm": "git-cz"
   },
@@ -33,6 +33,7 @@
   "main": "index.js",
   "devDependencies": {
     "commitizen": "^3.0.5",
+    "cross-env": "^5.2.0",
     "cz-conventional-changelog": "^2.1.0",
     "eslint": "5.3.0",
     "eslint-config-airbnb": "17.1.0",
@@ -43,6 +44,7 @@
     "eslint-plugin-react": "^7.11.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.16.4",
+    "rimraf": "^2.6.3",
     "standard-version": "^5.0.0"
   },
   "author": "datchley@pieriandx.com",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "start": "run-p start:*",
     "start:app": "react-scripts start",
-    "start:server": "cross-env PORT=5000 yarn --cwd ./api start:local",
+    "start:server": "cross-env PORT=5000 yarn --cwd api start:local",
     "build": "react-scripts build",
     "test": "cross-env CI=true react-scripts test",
     "test:coverage": "npm test -- --coverage",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2421,6 +2421,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-env@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
+  dependencies:
+    cross-spawn "^6.0.5"
+    is-windows "^1.0.0"
+
 cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -5012,7 +5019,7 @@ is-windows@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
 
-is-windows@^1.0.2:
+is-windows@^1.0.0, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
@@ -8195,7 +8202,7 @@ right-pad@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/right-pad/-/right-pad-1.0.1.tgz#8ca08c2cbb5b55e74dafa96bf7fd1a27d568c8d0"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@~2.6.2:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3, rimraf@~2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   dependencies:


### PR DESCRIPTION
* update npm scripts to use `rimraf` (rather than `rm -f`) and `cross-env` (rather than setting env vars as XXX=value)
